### PR TITLE
TCP calls nc_function_score() directly

### DIFF
--- a/nonconformist/cp.py
+++ b/nonconformist/cp.py
@@ -133,14 +133,14 @@ class TcpClassifier(BaseEstimator, ClassifierMixin):
 				train_x = np.vstack([self.train_x, x[i, :]])
 				train_y = np.hstack([self.train_y, y])
 				self.base_icp.fit(train_x, train_y)
-				self.base_icp.calibrate(train_x, train_y)
-				p[i, j] = self.base_icp.predict(np.array([x[i, :]]))[0, j]
-				p[i, j] *= (n_train + 2)
+				scores = self.base_icp.nc_function.score(train_x, train_y)
+				n_gt = sum(scores > scores[-1])
+				n_eq = sum(scores == scores[-1])
 				if self.smoothing:
-					p[i, j] -= np.random.uniform(0, 1)
+					r = np.random.uniform(0, 1)
+					p[i, j] = (n_gt + r*n_eq) / (n_train + 1)
 				else:
-					p[i, j] -= 1
-				p[i, j] /= (n_train + 1)
+					p[i, j] = (n_gt + n_eq) / (n_train + 1)
 
 		if significance is not None:
 			return p > significance


### PR DESCRIPTION
Fixes #10

Quick fix, although could be slightly more efficient (e.g., it doesn't do any clever stuff to compute `n_eq` and `n_gt`). Also, since I'm not familiar with your code, there may be better ways to address this.

In my experiments, p-values are in [0,1] now.